### PR TITLE
Add node count and first node columns to jobs table

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,8 @@ from datetime import datetime, timezone
 
 import pytest
 
-from pbs_tui.app import PBSTUI, _env_flag, run
+from pbs_tui.app import PBSTUI, _env_flag, run, _job_node_summary
+from pbs_tui.data import Job
 from pbs_tui.samples import sample_snapshot
 
 
@@ -49,6 +50,7 @@ def test_run_inline_prints_rich_table(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "PBS Jobs as of" in captured.out
     assert "Job ID" in captured.out
+    assert "Node Count" in captured.out
     assert "climate_model" in captured.out
     assert "sample data" in captured.err.lower()
 
@@ -73,6 +75,7 @@ def test_run_inline_writes_markdown_file(monkeypatch, tmp_path, capsys):
     contents = output_path.read_text()
     assert contents.startswith("### PBS Jobs as of")
     assert "| Job ID |" in contents
+    assert "| Node Count |" in contents
     assert "climate_model" in contents
     assert "PBS Jobs as of" in captured.out
     assert "sample data" in captured.err.lower()
@@ -88,3 +91,61 @@ def test_run_file_without_inline_exits(monkeypatch):
 
     with pytest.raises(SystemExit):
         run(argv=["--file", "out.md"], fetcher=DummyFetcher())
+
+
+def test_job_node_summary_exec_host():
+    job = Job(
+        id="1",
+        name="demo",
+        user="alice",
+        queue="work",
+        state="R",
+        exec_host="nodeA/0+nodeA/1+nodeB/0*2",
+        nodes="2:ppn=1",
+    )
+    count, first = _job_node_summary(job)
+    assert count == 2
+    assert first == "nodeA"
+
+
+def test_job_node_summary_requested_nodes():
+    job = Job(
+        id="2",
+        name="demo",
+        user="bob",
+        queue="work",
+        state="Q",
+        nodes="node01+node02:ppn=2",
+    )
+    count, first = _job_node_summary(job)
+    assert count == 2
+    assert first == "node01"
+
+
+def test_job_node_summary_numeric_fallback():
+    job = Job(
+        id="3",
+        name="demo",
+        user="carol",
+        queue="work",
+        state="Q",
+        nodes="3:ppn=64",
+        resources_requested={"nodes": "3:ppn=64"},
+    )
+    count, first = _job_node_summary(job)
+    assert count == 3
+    assert first is None
+
+
+def test_job_node_summary_nodect_fallback():
+    job = Job(
+        id="4",
+        name="demo",
+        user="dave",
+        queue="work",
+        state="Q",
+        resources_requested={"nodect": "5"},
+    )
+    count, first = _job_node_summary(job)
+    assert count == 5
+    assert first is None


### PR DESCRIPTION
## Summary
- add helpers to derive node lists and counts from job data
- display node count and first node in the TUI jobs table, inline table, and Markdown snapshot
- extend application tests to cover the new node summary behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca18e9bf488320a37e8c51560ecb4a