### PR TITLE
Add release automation workflow

### DIFF
--- a/.github/scripts/extract_metadata.py
+++ b/.github/scripts/extract_metadata.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import tomlkit
+
+
+def write_outputs(name: str, version: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    path = Path(output_path)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(f"name={name}\n")
+        file.write(f"version={version}\n")
+
+
+def check_pypi(name: str, version: str, token: str | None) -> None:
+    if not token:
+        return
+
+    url = f"https://pypi.org/pypi/{name}/json"
+    try:
+        with urllib.request.urlopen(url) as response:  # noqa: S310 - HTTPS endpoint
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return
+        raise
+    except urllib.error.URLError:
+        # Network errors should not block the release entirely.
+        return
+
+    if version in payload.get("releases", {}):
+        message = f"Version {version} of {name} already exists on PyPI."
+        print(message)
+        sys.exit(1)
+
+
+def main() -> None:
+    pyproject_path = Path("pyproject.toml")
+    data = tomlkit.parse(pyproject_path.read_text(encoding="utf-8"))
+
+    project = data["project"]
+    name = project["name"]
+    version = project["version"]
+
+    write_outputs(name=name, version=version)
+    check_pypi(name=name, version=version, token=os.environ.get("PYPI_TOKEN"))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/extract_release_notes.py
+++ b/.github/scripts/extract_release_notes.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from keepachangelog import to_dict
+
+
+KNOWN_SECTIONS = (
+    "added",
+    "changed",
+    "deprecated",
+    "removed",
+    "fixed",
+    "security",
+)
+
+
+def build_release_notes(version: str, changelog_path: Path) -> list[str]:
+    entries = to_dict(str(changelog_path))
+    entry = entries.get(version)
+    if entry is None:
+        raise SystemExit(f"No release notes found for version {version} in {changelog_path}")
+
+    lines: list[str] = []
+    metadata = entry.get("metadata", {})
+    header = version
+    release_date = metadata.get("release_date")
+    if release_date:
+        header = f"{header} - {release_date}"
+    lines.append(f"## {header}")
+
+    def render_section(section_name: str) -> None:
+        items = entry.get(section_name)
+        if not items:
+            return
+        title = section_name.replace("_", " ").title()
+        lines.append("")
+        lines.append(f"### {title}")
+        for item in items:
+            lines.append(f"- {item}")
+
+    for section in KNOWN_SECTIONS:
+        render_section(section)
+
+    for section in sorted(key for key in entry.keys() if key not in {"metadata", *KNOWN_SECTIONS}):
+        render_section(section)
+
+    return lines
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output", type=Path, default=Path(".github/current_release_notes.md"))
+    parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
+    args = parser.parse_args()
+
+    lines = build_release_notes(version=args.version, changelog_path=args.changelog)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    env:
+      PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run tests
+        run: uv run pytest
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        if: env.PYPI_TOKEN != ''
+        env:
+          UV_PUBLISH_TOKEN: ${{ env.PYPI_TOKEN }}
+        run: uv publish --token "$UV_PUBLISH_TOKEN" --skip-existing
+
+      - name: Determine release version
+        id: version
+        run: |
+          VERSION=$(python - <<'PY'
+import tomllib
+with open("pyproject.toml", "rb") as f:
+    data = tomllib.load(f)
+print(data["project"]["version"])
+PY
+)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          body_path: CHANGELOG.md
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,9 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
 
 jobs:
   release:
@@ -24,6 +25,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .venv
+            ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+
       - name: Install dependencies
         run: uv sync --dev
 
@@ -36,110 +45,23 @@ jobs:
       - name: Install release tooling
         run: python -m pip install keepachangelog tomlkit
 
-      - name: Collect project metadata and verify PyPI availability
+      - name: Extract metadata
         id: metadata
         env:
           PYPI_TOKEN: ${{ env.PYPI_TOKEN }}
-        run: |
-          python - <<'PY'
-import json
-import os
-import sys
-import urllib.error
-import urllib.request
-from pathlib import Path
-
-import tomlkit
-
-pyproject = tomlkit.parse(Path("pyproject.toml").read_text(encoding="utf-8"))
-project = pyproject["project"]
-name = project["name"]
-version = project["version"]
-
-output_path = Path(os.environ["GITHUB_OUTPUT"])
-with output_path.open("a", encoding="utf-8") as output:
-    output.write(f"name={name}\n")
-    output.write(f"version={version}\n")
-
-if not os.environ.get("PYPI_TOKEN"):
-    sys.exit(0)
-
-url = f"https://pypi.org/pypi/{name}/json"
-try:
-    with urllib.request.urlopen(url) as response:
-        data = json.load(response)
-except urllib.error.HTTPError as exc:
-    if exc.code == 404:
-        sys.exit(0)
-    raise
-except urllib.error.URLError:
-    sys.exit(0)
-
-if version in data.get("releases", {}):
-    print(f"Version {version} of {name} already exists on PyPI.")
-    sys.exit(1)
-PY
+        run: python .github/scripts/extract_metadata.py
 
       - name: Publish to PyPI
-        if: env.PYPI_TOKEN != ''
+        if: env.PYPI_TOKEN != '' && steps.metadata.outcome == 'success'
         env:
           UV_PUBLISH_TOKEN: ${{ env.PYPI_TOKEN }}
         run: uv publish --token "$UV_PUBLISH_TOKEN"
 
       - name: Extract current version release notes
         run: |
-          python - <<'PY'
-from pathlib import Path
-
-from keepachangelog import to_dict
-
-version = "${{ steps.metadata.outputs.version }}"
-entries = to_dict("CHANGELOG.md")
-entry = entries.get(version)
-if entry is None:
-    raise SystemExit(f"No release notes found for version {version} in CHANGELOG.md")
-
-lines = []
-metadata = entry.get("metadata", {})
-header = version
-release_date = metadata.get("release_date")
-if release_date:
-    header = f"{header} - {release_date}"
-lines.append(f"## {header}")
-
-known_sections = [
-    "added",
-    "changed",
-    "deprecated",
-    "removed",
-    "fixed",
-    "security",
-]
-
-def render_section(section_name: str) -> None:
-    items = entry.get(section_name)
-    if not items:
-        return
-    title = section_name.replace("_", " ").title()
-    lines.append("")
-    lines.append(f"### {title}")
-    for item in items:
-        lines.append(f"- {item}")
-
-for section in known_sections:
-    render_section(section)
-
-other_sections = sorted(
-    key for key in entry.keys()
-    if key not in {"metadata", *known_sections}
-)
-for section in other_sections:
-    render_section(section)
-
-notes_path = Path(".github") / "current_release_notes.md"
-notes_path.parent.mkdir(parents=True, exist_ok=True)
-notes_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-PY
+          python .github/scripts/extract_release_notes.py \
+            --version "${{ steps.metadata.outputs.version }}" \
+            --output .github/current_release_notes.md
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,30 +37,71 @@ jobs:
       - name: Build package
         run: uv build
 
+      - name: Install tomlkit
+        run: python -m pip install tomlkit
+
+      - name: Determine project metadata
+        id: metadata
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+import tomlkit
+from pathlib import Path
+
+data = tomlkit.parse(Path("pyproject.toml").read_text(encoding="utf-8"))
+project = data["project"]
+print(f"name={project['name']}")
+print(f"version={project['version']}")
+PY
+
+      - name: Verify release is new on PyPI
+        if: env.PYPI_TOKEN != ''
+        run: |
+          python - <<'PY'
+import json
+import sys
+import urllib.error
+import urllib.request
+
+name = "${{ steps.metadata.outputs.name }}"
+version = "${{ steps.metadata.outputs.version }}"
+url = f"https://pypi.org/pypi/{name}/json"
+
+try:
+    with urllib.request.urlopen(url) as response:
+        data = json.load(response)
+except urllib.error.HTTPError as exc:
+    if exc.code == 404:
+        sys.exit(0)
+    raise
+except urllib.error.URLError:
+    sys.exit(0)
+
+if version in data.get("releases", {}):
+    print(f"Version {version} of {name} already exists on PyPI.")
+    sys.exit(1)
+PY
+
       - name: Publish to PyPI
         if: env.PYPI_TOKEN != ''
         env:
           UV_PUBLISH_TOKEN: ${{ env.PYPI_TOKEN }}
-        run: uv publish --token "$UV_PUBLISH_TOKEN" --skip-existing
+        run: uv publish --token "$UV_PUBLISH_TOKEN"
 
-      - name: Determine release version
-        id: version
+      - name: Extract current version release notes
         run: |
-          VERSION=$(python - <<'PY'
-import tomllib
-with open("pyproject.toml", "rb") as f:
-    data = tomllib.load(f)
-print(data["project"]["version"])
-PY
-)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          VERSION="${{ steps.metadata.outputs.version }}"
+          awk "/^## \\[?${VERSION}\\]?/ {flag=1; print; next} /^## / {flag=0} flag" CHANGELOG.md > .github/current_release_notes.md
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: v${{ steps.version.outputs.version }}
-          body_path: CHANGELOG.md
+          tag_name: v${{ steps.metadata.outputs.version }}
+          name: v${{ steps.metadata.outputs.version }}
+          body_path: .github/current_release_notes.md
           files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean up release notes
+        if: always()
+        run: rm -f .github/current_release_notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,12 @@
 name: Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -20,8 +18,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v1
@@ -37,35 +33,38 @@ jobs:
       - name: Build package
         run: uv build
 
-      - name: Install tomlkit
-        run: python -m pip install tomlkit
+      - name: Install release tooling
+        run: python -m pip install keepachangelog tomlkit
 
-      - name: Determine project metadata
+      - name: Collect project metadata and verify PyPI availability
         id: metadata
-        run: |
-          python - <<'PY' >> "$GITHUB_OUTPUT"
-import tomlkit
-from pathlib import Path
-
-data = tomlkit.parse(Path("pyproject.toml").read_text(encoding="utf-8"))
-project = data["project"]
-print(f"name={project['name']}")
-print(f"version={project['version']}")
-PY
-
-      - name: Verify release is new on PyPI
-        if: env.PYPI_TOKEN != ''
+        env:
+          PYPI_TOKEN: ${{ env.PYPI_TOKEN }}
         run: |
           python - <<'PY'
 import json
+import os
 import sys
 import urllib.error
 import urllib.request
+from pathlib import Path
 
-name = "${{ steps.metadata.outputs.name }}"
-version = "${{ steps.metadata.outputs.version }}"
+import tomlkit
+
+pyproject = tomlkit.parse(Path("pyproject.toml").read_text(encoding="utf-8"))
+project = pyproject["project"]
+name = project["name"]
+version = project["version"]
+
+output_path = Path(os.environ["GITHUB_OUTPUT"])
+with output_path.open("a", encoding="utf-8") as output:
+    output.write(f"name={name}\n")
+    output.write(f"version={version}\n")
+
+if not os.environ.get("PYPI_TOKEN"):
+    sys.exit(0)
+
 url = f"https://pypi.org/pypi/{name}/json"
-
 try:
     with urllib.request.urlopen(url) as response:
         data = json.load(response)
@@ -89,8 +88,58 @@ PY
 
       - name: Extract current version release notes
         run: |
-          VERSION="${{ steps.metadata.outputs.version }}"
-          awk "/^## \\[?${VERSION}\\]?/ {flag=1; print; next} /^## / {flag=0} flag" CHANGELOG.md > .github/current_release_notes.md
+          python - <<'PY'
+from pathlib import Path
+
+from keepachangelog import to_dict
+
+version = "${{ steps.metadata.outputs.version }}"
+entries = to_dict("CHANGELOG.md")
+entry = entries.get(version)
+if entry is None:
+    raise SystemExit(f"No release notes found for version {version} in CHANGELOG.md")
+
+lines = []
+metadata = entry.get("metadata", {})
+header = version
+release_date = metadata.get("release_date")
+if release_date:
+    header = f"{header} - {release_date}"
+lines.append(f"## {header}")
+
+known_sections = [
+    "added",
+    "changed",
+    "deprecated",
+    "removed",
+    "fixed",
+    "security",
+]
+
+def render_section(section_name: str) -> None:
+    items = entry.get(section_name)
+    if not items:
+        return
+    title = section_name.replace("_", " ").title()
+    lines.append("")
+    lines.append(f"### {title}")
+    for item in items:
+        lines.append(f"- {item}")
+
+for section in known_sections:
+    render_section(section)
+
+other_sections = sorted(
+    key for key in entry.keys()
+    if key not in {"metadata", *known_sections}
+)
+for section in other_sections:
+    render_section(section)
+
+notes_path = Path(".github") / "current_release_notes.md"
+notes_path.parent.mkdir(parents=True, exist_ok=True)
+notes_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
- add a release workflow that triggers when pull requests are merged into main
- install dependencies with uv, run tests, publish to PyPI, and publish a release with changelog notes

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cbf3e23ef88320ac4fb61ae65230f6

## Summary by Sourcery

Add a GitHub Actions workflow to automate releases on pushes to main, including building, testing, publishing to PyPI, extracting changelog-based release notes, and creating GitHub releases

Enhancements:
- Generate release notes from CHANGELOG.md sections for GitHub release body

CI:
- Introduce .github/workflows/release.yml to orchestrate checkout, uv setup, dependency installation, testing, building, and publishing

Deployment:
- Extract project metadata and verify PyPI availability before publishing distributions
- Publish package to PyPI and create a GitHub release with notes generated from CHANGELOG.md