### PR TITLE
Fix: Publish to PyPI in PR-merge run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   release-and-publish:
     if: >-
-      (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: release v')) ||
+      (github.event_name == 'push') ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     environment:
@@ -246,15 +246,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # --- Publish steps (tag push only) ---
-      # The PR-merge path above creates and pushes a tag, which triggers
-      # a separate tag-push run that handles the actual publish.  This
-      # avoids double-publishing.
+      # --- Publish steps ---
+      # On PR merge: build and publish after the release commit.
+      # On manual tag push: build and publish directly.
+      # Note: tags pushed by GITHUB_TOKEN don't re-trigger workflows,
+      # so the PR-merge path must publish in the same run.
 
       - name: Build package
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        if: >-
+          (env.IS_RELEASE == 'true' && steps.bump_level.outputs.skip_release != 'true') ||
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
         run: uv build
 
       - name: Publish to PyPI
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        if: >-
+          (env.IS_RELEASE == 'true' && steps.bump_level.outputs.skip_release != 'true') ||
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
         run: uv publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,14 +252,16 @@ jobs:
       # Note: tags pushed by GITHUB_TOKEN don't re-trigger workflows,
       # so the PR-merge path must publish in the same run.
 
-      - name: Build package
+      - name: Set publish flag
         if: >-
           (env.IS_RELEASE == 'true' && steps.bump_level.outputs.skip_release != 'true') ||
           (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        run: echo "SHOULD_PUBLISH=true" >> "$GITHUB_ENV"
+
+      - name: Build package
+        if: env.SHOULD_PUBLISH == 'true'
         run: uv build
 
       - name: Publish to PyPI
-        if: >-
-          (env.IS_RELEASE == 'true' && steps.bump_level.outputs.skip_release != 'true') ||
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        if: env.SHOULD_PUBLISH == 'true'
         run: uv publish


### PR DESCRIPTION
## Summary

- Build and publish to PyPI in the same workflow run as the release steps, instead of relying on a separate tag-push run

## Problem

Tags pushed by `GITHUB_TOKEN` don't trigger workflow runs ([GitHub Actions docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)). The previous design expected the tag push to fire a second run for publishing, but it never does — so Build/Publish were always skipped.

## Fix

Publish steps now run in both paths:
- **PR merge**: after version bump, changelog, commit, tag, and GitHub release
- **Manual tag push**: for `v*` tags pushed directly (e.g. with a PAT)

Also removes the stale `!startsWith(head_commit.message, 'chore: release v')` guard.

## Test plan

- [ ] Merge this PR and verify `uv build` + `uv publish` execute in the workflow run

## Summary by Sourcery

Update the release workflow so PyPI build and publish steps run in the same workflow execution as the release, covering both PR merges and manual tag pushes.

CI:
- Adjust release workflow conditions to always run on push events and on merged pull requests.
- Run package build and publish steps during PR-merge releases as well as for manually pushed version tags, removing the guard that previously prevented execution.