### PR TITLE
fix: Make Racks-tab job list scrollable + add --dummy flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ track workload health in real time.
   The `ansi-*` variants use muted 256-color palette tones that blend with your terminal
   colorscheme. Switch via the command palette (`Ctrl+P`).
 - **Fallback sample data** – bundled realistic mock cluster (~560 nodes, ~40 jobs) for demoing
-  without a production scheduler (`PBS_TUI_SAMPLE_DATA=1`).
+  without a production scheduler (`pbs-tui --dummy`, or `PBS_TUI_SAMPLE_DATA=1`).
 - **Inline snapshot** – render the current queue as a Rich table with `pbs-tui --inline` and
   optionally write a Markdown summary alongside it.
 
@@ -138,9 +138,10 @@ Use tab and the arrow keys/`PageUp`/`PageDown` to move through rows once a table
 
 ### Sample mode
 
-If you want to explore the UI without a live PBS cluster, export `PBS_TUI_SAMPLE_DATA=1`
-(or pass `force_sample=True` to `PBSDataFetcher`). The application will display bundled example
-jobs, nodes, and queues along with a warning banner indicating that the data is synthetic.
+If you want to explore the UI without a live PBS cluster, run `pbs-tui --dummy` (aliases:
+`--fake`, `--sample`), export `PBS_TUI_SAMPLE_DATA=1`, or pass `force_sample=True` to
+`PBSDataFetcher`. The application will display bundled example jobs, nodes, and queues along
+with a warning banner indicating that the data is synthetic.
 
 ### Headless / automated runs
 

--- a/src/pbs_tui/app.py
+++ b/src/pbs_tui/app.py
@@ -1046,9 +1046,25 @@ def run(
         metavar="SECONDS",
         help="How often the TUI refreshes PBS data (default: 30).",
     )
+    parser.add_argument(
+        "--dummy",
+        "--fake",
+        "--sample",
+        dest="dummy",
+        action="store_true",
+        help=(
+            "Use bundled sample data instead of querying PBS "
+            "(equivalent to setting PBS_TUI_SAMPLE_DATA=1)."
+        ),
+    )
     args = parser.parse_args(argv)
 
-    fetcher_instance = fetcher or PBSDataFetcher()
+    if fetcher is not None:
+        fetcher_instance = fetcher
+    elif args.dummy:
+        fetcher_instance = PBSDataFetcher(force_sample=True)
+    else:
+        fetcher_instance = PBSDataFetcher()
 
     if args.file and not args.inline:
         parser.error("--file can only be used together with --inline")

--- a/src/pbs_tui/fetcher.py
+++ b/src/pbs_tui/fetcher.py
@@ -251,7 +251,8 @@ class PBSDataFetcher:
             snapshot = sample_snapshot()
             snapshot.errors.insert(
                 0,
-                "Using bundled sample data (--dummy / PBS_TUI_SAMPLE_DATA).",
+                "Using bundled sample data "
+                "(--dummy/--fake/--sample or PBS_TUI_SAMPLE_DATA).",
             )
             return snapshot
 

--- a/src/pbs_tui/fetcher.py
+++ b/src/pbs_tui/fetcher.py
@@ -251,7 +251,7 @@ class PBSDataFetcher:
             snapshot = sample_snapshot()
             snapshot.errors.insert(
                 0,
-                "Using bundled sample data because PBS_TUI_SAMPLE_DATA was set.",
+                "Using bundled sample data (--dummy / PBS_TUI_SAMPLE_DATA).",
             )
             return snapshot
 

--- a/src/pbs_tui/rack_grid.py
+++ b/src/pbs_tui/rack_grid.py
@@ -24,9 +24,13 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
-from rich.console import RenderableType
 from rich.text import Text
-from textual.containers import Horizontal, ScrollableContainer, Vertical
+from textual.containers import (
+    Horizontal,
+    ScrollableContainer,
+    Vertical,
+    VerticalScroll,
+)
 from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Static
@@ -613,8 +617,56 @@ class _RackPanel(ScrollableContainer):
             self.post_message(self.CellClicked(node_name=None, rack_name=rack_name))
 
 
-class _JobListWidget(Widget):
-    """Sidebar listing running jobs; emits JobChosen on selection."""
+class _JobRow(Static):
+    """A single clickable job entry inside the sidebar list.
+
+    One widget per entry means Textual routes clicks straight to the right row
+    regardless of scroll position or line-wrapping, and the cursor can be
+    scrolled into view with ``scroll_to_widget`` — no manual coordinate math.
+    """
+
+    DEFAULT_CSS = """
+    _JobRow {
+        width: 1fr;
+        height: auto;
+    }
+    """
+
+    def __init__(self, index: int, job_id: str, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.index = index
+        self.job_id = job_id
+
+    def on_click(self, event) -> None:
+        # Stop the click bubbling to the container's filter-chip handler.
+        event.stop()
+        self.post_message(_JobListWidget.RowClicked(self.index))
+
+
+class _JobListFilterChip(Static):
+    """Header chip shown when a rack filter is active; clicking it clears."""
+
+    DEFAULT_CSS = """
+    _JobListFilterChip {
+        width: 1fr;
+        height: auto;
+        margin-bottom: 1;
+    }
+    """
+
+    def on_click(self, event) -> None:
+        event.stop()
+        self.post_message(_JobListWidget.FilterCleared())
+
+
+class _JobListWidget(VerticalScroll):
+    """Scrollable sidebar listing running jobs; emits JobChosen on selection.
+
+    Implemented as a :class:`VerticalScroll` holding one :class:`_JobRow` child
+    per entry (plus an optional filter chip).  This makes the list scroll when
+    it overflows the viewport — a plain ``Widget`` that renders its own ``Text``
+    is clamped to the viewport height and never scrolls.
+    """
 
     DEFAULT_CSS = """
     _JobListWidget {
@@ -646,6 +698,11 @@ class _JobListWidget(Widget):
     class FilterCleared(Message):
         pass
 
+    class RowClicked(Message):
+        def __init__(self, index: int) -> None:
+            super().__init__()
+            self.index = index
+
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._entries: List[JobListEntry] = []
@@ -653,10 +710,11 @@ class _JobListWidget(Widget):
         self._palette: Optional[Palette] = None
         self._selected_id: Optional[str] = None
         self._rack_filter: Optional[str] = None
-        self._content: RenderableType = Text()
 
-    def render(self) -> RenderableType:
-        return self._content
+    def on_mount(self) -> None:
+        # The parent may call update() before this widget is mounted (during its
+        # own compose/rebuild). Render whatever state we captured once mounted.
+        self._rebuild_children()
 
     def update(self, entries: List[JobListEntry], palette: Palette,
                selected_id: Optional[str], rack_filter: Optional[str]) -> None:
@@ -665,41 +723,68 @@ class _JobListWidget(Widget):
         self._selected_id = selected_id
         self._rack_filter = rack_filter
         self._cursor = max(0, min(self._cursor, len(entries) - 1))
-        self._rebuild_content()
-        self.refresh()
+        self._rebuild_children()
 
-    def _rebuild_content(self) -> None:
-        text = Text()
+    def _rebuild_children(self) -> None:
+        # Only reconcile once mounted; before mount there is no place to put
+        # children (update() may be called by the parent during its own build).
+        if not self.is_mounted:
+            return
+        self.remove_children()
+        widgets: List[Widget] = []
         if self._rack_filter:
-            text.append("Filtered: ", style="dim")
-            text.append(self._rack_filter, style="bold")
-            text.append(f"  ({len(self._entries)} jobs)\n", style="dim")
-            text.append("[clear: esc or click chip]\n\n", style="dim")
+            chip = Text()
+            chip.append("Filtered: ", style="dim")
+            chip.append(self._rack_filter, style="bold")
+            chip.append(f"  ({len(self._entries)} jobs)\n", style="dim")
+            chip.append("[clear: esc or click chip]", style="dim")
+            widgets.append(_JobListFilterChip(chip))
         if not self._entries:
-            text.append("(no running jobs)", style="dim")
-            self._content = text
+            widgets.append(Static(Text("(no running jobs)", style="dim")))
+        elif self._palette is None:
+            widgets.append(Static(Text("(loading…)", style="dim")))
+        else:
+            for i, entry in enumerate(self._entries):
+                row = _JobRow(i, entry.job_id)
+                row.update(self._render_row(i, entry))
+                widgets.append(row)
+        self.mount_all(widgets)
+
+    def _render_row(self, index: int, entry: JobListEntry) -> Text:
+        assert self._palette is not None
+        prefix = "▶ " if index == self._cursor else "  "
+        text = Text(prefix)
+        text.append_text(render_job_list_entry(
+            entry, self._palette,
+            selected=(self._selected_id == entry.job_id),
+        ))
+        return text
+
+    def _refresh_row(self, index: int) -> None:
+        """Re-render a single row's content in place (cheap cursor repaint)."""
+        if not (0 <= index < len(self._entries)) or self._palette is None:
             return
-        if self._palette is None:
-            # No palette yet — render a placeholder until the parent calls update()
-            text.append("(loading…)", style="dim")
-            self._content = text
-            return
-        for i, entry in enumerate(self._entries):
-            prefix = "▶ " if i == self._cursor else "  "
-            text.append(prefix)
-            text.append_text(render_job_list_entry(
-                entry, self._palette,
-                selected=(self._selected_id == entry.job_id),
-            ))
-            text.append("\n")
-        self._content = text
+        rows = self.query(_JobRow)
+        for row in rows:
+            if row.index == index:
+                row.update(self._render_row(index, self._entries[index]))
+                return
+
+    def _scroll_cursor_into_view(self) -> None:
+        for row in self.query(_JobRow):
+            if row.index == self._cursor:
+                self.scroll_to_widget(row, animate=False)
+                return
 
     def action_move(self, delta: int) -> None:
         if not self._entries:
             return
+        previous = self._cursor
         self._cursor = (self._cursor + delta) % len(self._entries)
-        self._rebuild_content()
-        self.refresh()
+        # Repaint only the two affected rows instead of rebuilding the list.
+        self._refresh_row(previous)
+        self._refresh_row(self._cursor)
+        self._scroll_cursor_into_view()
 
     def action_choose(self) -> None:
         if not self._entries:
@@ -710,21 +795,16 @@ class _JobListWidget(Widget):
     def action_clear(self) -> None:
         self.post_message(self.FilterCleared())
 
-    def on_click(self, event) -> None:
-        # When a rack filter is active the header occupies 3 lines (chip line 0,
-        # chip line 1, blank line 2).  Clicking anywhere in that header area
-        # (y < 3) clears the filter — the chip text says "esc or click chip".
-        if self._rack_filter and int(event.y) < 3:
-            self.post_message(self.FilterCleared())
+    def on__job_list_widget_row_clicked(self, event: "RowClicked") -> None:
+        event.stop()
+        index = event.index
+        if not (0 <= index < len(self._entries)):
             return
-        # Map click row to an entry index. Header takes 0-2 lines depending on filter.
-        offset = 3 if self._rack_filter else 0
-        row = int(event.y) - offset
-        if 0 <= row < len(self._entries):
-            self._cursor = row
-            self._rebuild_content()
-            self.refresh()
-            self.post_message(self.JobChosen(self._entries[row].job_id))
+        previous = self._cursor
+        self._cursor = index
+        self._refresh_row(previous)
+        self._refresh_row(index)
+        self.post_message(self.JobChosen(self._entries[index].job_id))
 
 
 # ---------------------------------------------------------------------------

--- a/src/pbs_tui/rack_grid.py
+++ b/src/pbs_tui/rack_grid.py
@@ -710,6 +710,9 @@ class _JobListWidget(VerticalScroll):
         self._palette: Optional[Palette] = None
         self._selected_id: Optional[str] = None
         self._rack_filter: Optional[str] = None
+        # Row widgets indexed by entry position, so repaint/scroll are O(1)
+        # instead of scanning the DOM on every keypress.
+        self._rows: List[_JobRow] = []
 
     def on_mount(self) -> None:
         # The parent may call update() before this widget is mounted (during its
@@ -731,6 +734,7 @@ class _JobListWidget(VerticalScroll):
         if not self.is_mounted:
             return
         self.remove_children()
+        self._rows = []
         widgets: List[Widget] = []
         if self._rack_filter:
             chip = Text()
@@ -747,6 +751,7 @@ class _JobListWidget(VerticalScroll):
             for i, entry in enumerate(self._entries):
                 row = _JobRow(i, entry.job_id)
                 row.update(self._render_row(i, entry))
+                self._rows.append(row)
                 widgets.append(row)
         self.mount_all(widgets)
 
@@ -762,19 +767,13 @@ class _JobListWidget(VerticalScroll):
 
     def _refresh_row(self, index: int) -> None:
         """Re-render a single row's content in place (cheap cursor repaint)."""
-        if not (0 <= index < len(self._entries)) or self._palette is None:
+        if self._palette is None or not (0 <= index < len(self._rows)):
             return
-        rows = self.query(_JobRow)
-        for row in rows:
-            if row.index == index:
-                row.update(self._render_row(index, self._entries[index]))
-                return
+        self._rows[index].update(self._render_row(index, self._entries[index]))
 
     def _scroll_cursor_into_view(self) -> None:
-        for row in self.query(_JobRow):
-            if row.index == self._cursor:
-                self.scroll_to_widget(row, animate=False)
-                return
+        if 0 <= self._cursor < len(self._rows):
+            self.scroll_to_widget(self._rows[self._cursor], animate=False)
 
     def action_move(self, delta: int) -> None:
         if not self._entries:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -628,18 +628,38 @@ def test_app_includes_racks_tab():
 
 
 
-def test_run_dummy_flag_uses_sample_data(capsys):
-    """`--dummy` (and its aliases) forces bundled sample data via --inline."""
-    run(["--inline", "--dummy"])
-    out = capsys.readouterr().out
-    # Sample snapshot always contains a known bundled user/job; assert we got
-    # a populated jobs table rather than an empty/live result.
-    assert "PBS Jobs" in out
-    assert len(out.strip()) > 0
+class _ProbeFetcher:
+    """Records the force_sample kwarg it was constructed with and returns a
+    sample snapshot so the --inline path completes without a live PBS."""
+
+    constructed_with: "list[bool]" = []
+
+    def __init__(self, *args, force_sample=None, **kwargs):
+        type(self).constructed_with.append(bool(force_sample))
+
+    async def fetch_snapshot(self):
+        return sample_snapshot()
 
 
-def test_run_fake_alias_matches_dummy(capsys):
-    """The --fake alias behaves identically to --dummy."""
-    run(["--inline", "--fake"])
-    out = capsys.readouterr().out
-    assert "PBS Jobs" in out
+@pytest.mark.parametrize("flag", ["--dummy", "--fake", "--sample"])
+def test_run_sample_flags_force_sample_data(flag, monkeypatch):
+    """Each sample-data alias must construct the fetcher with force_sample=True.
+
+    Asserting on stdout alone is a false positive: a machine without PBS falls
+    back to sample data even without the flag. Patch PBSDataFetcher and verify
+    the flag actually wires through to force_sample=True.
+    """
+    _ProbeFetcher.constructed_with = []
+    monkeypatch.setattr("pbs_tui.app.PBSDataFetcher", _ProbeFetcher)
+    run(["--inline", flag])
+    assert _ProbeFetcher.constructed_with == [True], (
+        f"{flag} should construct PBSDataFetcher(force_sample=True)"
+    )
+
+
+def test_run_without_sample_flag_does_not_force_sample(monkeypatch):
+    """Without a sample-data flag the fetcher is built normally (no forcing)."""
+    _ProbeFetcher.constructed_with = []
+    monkeypatch.setattr("pbs_tui.app.PBSDataFetcher", _ProbeFetcher)
+    run(["--inline"])
+    assert _ProbeFetcher.constructed_with == [False]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -626,3 +626,20 @@ def test_app_includes_racks_tab():
 
     asyncio.run(interact())
 
+
+
+def test_run_dummy_flag_uses_sample_data(capsys):
+    """`--dummy` (and its aliases) forces bundled sample data via --inline."""
+    run(["--inline", "--dummy"])
+    out = capsys.readouterr().out
+    # Sample snapshot always contains a known bundled user/job; assert we got
+    # a populated jobs table rather than an empty/live result.
+    assert "PBS Jobs" in out
+    assert len(out.strip()) > 0
+
+
+def test_run_fake_alias_matches_dummy(capsys):
+    """The --fake alias behaves identically to --dummy."""
+    run(["--inline", "--fake"])
+    out = capsys.readouterr().out
+    assert "PBS Jobs" in out

--- a/tests/test_rack_grid.py
+++ b/tests/test_rack_grid.py
@@ -357,3 +357,208 @@ def test_build_job_list_entries_filter_by_rack():
     entries = build_job_list_entries(snap, assignments, palette_index=palette_index,
                                      rack_filter="r1")
     assert [e.job_id for e in entries] == ["j1"]
+
+
+# ---------------------------------------------------------------------------
+# Job-list scrolling (right sidebar in the Racks tab)
+# ---------------------------------------------------------------------------
+
+
+def _many_entries(count: int) -> list:
+    """Build *count* JobListEntry rows for driving the sidebar widget."""
+    return [
+        JobListEntry(
+            job_id=f"j{i}",
+            user=f"user{i}",
+            queue="preemptable",
+            node_count=1,
+            palette_index=i,
+            time_remaining_str="63h48m",
+            nodes=[f"x{i}"],
+        )
+        for i in range(count)
+    ]
+
+
+def test_job_list_scrolls_when_entries_overflow_viewport():
+    """The sidebar must expose vertical scrolling when the running-job list is
+    taller than its viewport — otherwise off-screen jobs are unreachable.
+
+    Regression test: previously ``_JobListWidget`` subclassed a bare ``Widget``
+    and rendered its own ``Text``, so Textual clamped its virtual size to the
+    viewport and ``max_scroll_y`` stayed 0.
+    """
+    import asyncio
+
+    from textual.app import App, ComposeResult
+    from textual.containers import Horizontal
+
+    from pbs_tui.rack_grid import _JobListWidget
+
+    palette = _palette_many(50)
+    entries = _many_entries(50)
+
+    class Probe(App):
+        def compose(self) -> ComposeResult:
+            with Horizontal():
+                yield _JobListWidget(id="jl")
+
+    async def interact() -> None:
+        app = Probe()
+        async with app.run_test(size=(80, 24)) as pilot:
+            widget = app.query_one("#jl", _JobListWidget)
+            widget.update(entries, palette, selected_id=None, rack_filter=None)
+            widget.focus()
+            await pilot.pause()
+
+            assert widget.is_scrollable, "job list should be scrollable"
+            assert widget.max_scroll_y > 0, (
+                f"expected positive max_scroll_y, got {widget.max_scroll_y}; "
+                f"virtual height={widget.virtual_size.height}"
+            )
+
+            widget.scroll_end(animate=False)
+            await pilot.pause()
+            assert widget.scroll_offset.y > 0, "scroll_end should move the viewport"
+
+    asyncio.run(interact())
+
+
+def _palette_many(n: int) -> "Palette":
+    return Palette(
+        job_styles=[f"on color({16 + (i % 200)})" for i in range(max(1, n))],
+        agg_colors=["#445566"],
+        empty_style="on color(236)",
+    )
+
+
+def test_job_list_click_selects_correct_job_when_scrolled():
+    """Clicking a row after scrolling must select that row's job, not the row
+    that happens to sit at the same viewport offset.
+
+    Regression test: the old handler mapped ``event.y`` directly to an entry
+    index, which selected the wrong job once the list was scrolled.
+    """
+    import asyncio
+
+    from textual.app import App, ComposeResult
+    from textual.containers import Horizontal
+
+    from pbs_tui.rack_grid import _JobListWidget, _JobRow
+
+    palette = _palette_many(50)
+    entries = _many_entries(50)
+    chosen: list = []
+
+    class Probe(App):
+        def compose(self) -> ComposeResult:
+            with Horizontal():
+                yield _JobListWidget(id="jl")
+
+        def on__job_list_widget_job_chosen(self, event) -> None:
+            chosen.append(event.job_id)
+
+    async def interact() -> None:
+        app = Probe()
+        async with app.run_test(size=(80, 24)) as pilot:
+            widget = app.query_one("#jl", _JobListWidget)
+            widget.update(entries, palette, selected_id=None, rack_filter=None)
+            widget.focus()
+            await pilot.pause()
+
+            # Scroll well down the list, then click a row that is now on screen.
+            widget.scroll_to(y=30, animate=False)
+            await pilot.pause()
+
+            # Find a row widget that is actually visible in the viewport and
+            # click it; its job_id must be what gets chosen.
+            target = None
+            for row in widget.query(_JobRow):
+                if widget.scrollable_content_region.contains_region(row.region):
+                    target = row
+                    break
+            assert target is not None, "expected a visible row after scrolling"
+            expected_job = target.job_id
+            await pilot.click(target)
+            await pilot.pause()
+
+            assert chosen == [expected_job], (
+                f"clicked row {expected_job!r} but chose {chosen!r}"
+            )
+
+    asyncio.run(interact())
+
+
+def test_job_list_cursor_scrolls_into_view_on_arrow_navigation():
+    """Moving the cursor with arrow keys past the viewport edge must scroll the
+    list so the cursor stays visible."""
+    import asyncio
+
+    from textual.app import App, ComposeResult
+    from textual.containers import Horizontal
+
+    from pbs_tui.rack_grid import _JobListWidget
+
+    palette = _palette_many(50)
+    entries = _many_entries(50)
+
+    class Probe(App):
+        def compose(self) -> ComposeResult:
+            with Horizontal():
+                yield _JobListWidget(id="jl")
+
+    async def interact() -> None:
+        app = Probe()
+        async with app.run_test(size=(80, 24)) as pilot:
+            widget = app.query_one("#jl", _JobListWidget)
+            widget.update(entries, palette, selected_id=None, rack_filter=None)
+            widget.focus()
+            await pilot.pause()
+
+            assert widget.scroll_offset.y == 0
+            # Press up once: cursor wraps to the last entry, which is off-screen,
+            # so the list must scroll down to reveal it.
+            await pilot.press("up")
+            await pilot.pause()
+            assert widget.scroll_offset.y > 0, (
+                "cursor moved to the bottom entry but the list did not scroll"
+            )
+
+    asyncio.run(interact())
+
+
+def test_job_list_filter_chip_click_clears_filter():
+    """Clicking the filter chip in the header emits FilterCleared."""
+    import asyncio
+
+    from textual.app import App, ComposeResult
+    from textual.containers import Horizontal
+
+    from pbs_tui.rack_grid import _JobListWidget, _JobListFilterChip
+
+    palette = _palette_many(5)
+    entries = _many_entries(5)
+    cleared: list = []
+
+    class Probe(App):
+        def compose(self) -> ComposeResult:
+            with Horizontal():
+                yield _JobListWidget(id="jl")
+
+        def on__job_list_widget_filter_cleared(self, event) -> None:
+            cleared.append(True)
+
+    async def interact() -> None:
+        app = Probe()
+        async with app.run_test(size=(80, 24)) as pilot:
+            widget = app.query_one("#jl", _JobListWidget)
+            widget.update(entries, palette, selected_id=None, rack_filter="r1")
+            widget.focus()
+            await pilot.pause()
+
+            chip = app.query_one(_JobListFilterChip)
+            await pilot.click(chip)
+            await pilot.pause()
+            assert cleared, "clicking the filter chip should clear the filter"
+
+    asyncio.run(interact())


### PR DESCRIPTION
## Summary

Two changes, in separate commits:

### 1. Fix: Racks-tab job list is now scrollable

The right-pane job list wasn't scrollable — on a busy cluster the vast majority of running jobs were clipped off the bottom with no way to reach them.

**Root cause:** `_JobListWidget` subclassed the base `Widget` and returned its content from `render()`. A plain `Widget` doesn't measure its own rendered output, so Textual clamped its virtual size to the viewport height (`max_scroll_y` stayed `0`) and everything past the bottom edge was clipped. The `up`/`down` keys only moved a cursor; they never scrolled.

**Fix:** Rewrote `_JobListWidget` as a `VerticalScroll` holding one `_JobRow` child per entry (plus a `_JobListFilterChip` header). This is correct by construction:
- Scrolls when the list overflows — wheel, `pageup`/`pagedown`, `home`/`end` all work via inherited scroll bindings.
- Clicks select the right job even when scrolled (Textual routes clicks to the actual row widget — no fragile `event.y → index` math). The old handler also assumed one line per row, but rows wrap to two lines, so it mis-selected jobs *even before* any scrolling.
- Arrow-key cursor scrolls into view via `scroll_to_widget`.
- Scroll position is preserved across data refreshes.

### 2. Feat: `--dummy` CLI flag for sample data

Adds `--dummy` (aliases `--fake`, `--sample`) to run against bundled sample data without querying PBS, e.g. `uvx pbs-tui --dummy`. Works in both TUI and `--inline` modes. The existing `PBS_TUI_SAMPLE_DATA` env var still works.

## Testing

- `167 passed` — added 5 tests: scroll regression, click-under-scroll, cursor-follow, filter-chip clear, and two CLI-flag tests.
- Verified end-to-end by driving the real app on the Racks tab (22 sample jobs → `max_scroll_y=18`, scroll + navigation confirmed).
- `ruff` clean on all production files.

## Note (not addressed here)

While investigating, I noticed the sibling `_RackPanel.on_click` (the left grid) manually adds `scroll_offset` to click coordinates, which appears to double-count when the grid is scrolled — clicking a cell after scrolling selected the neighboring node in a probe. That's a separate latent bug; happy to follow up in another PR.

## Summary by Sourcery

Make the Racks tab job list a properly scrollable, per-row widget-based sidebar and introduce a --dummy/--fake/--sample flag to run the app against bundled sample data, updating tests and messaging accordingly.

New Features:
- Add a --dummy/--fake/--sample CLI flag to run against bundled sample data without querying PBS.

Bug Fixes:
- Make the Racks tab job list scrollable so off-screen jobs can be accessed.
- Ensure clicking a job row while scrolled selects the correct job and keeps cursor navigation in view.

Enhancements:
- Refactor the Racks tab job list into a VerticalScroll with per-row widgets and a clickable filter chip header for more robust interaction and scrolling behavior.
- Clarify the sample-data fetcher message to mention the --dummy flag alongside PBS_TUI_SAMPLE_DATA.

Tests:
- Add integration-style tests covering job-list scrolling, click selection under scroll, cursor-follow behavior, and filter-chip clearing.
- Add CLI tests verifying that --dummy and its --fake alias use bundled sample data in inline mode.