### PR TITLE
fix: Correct _RackPanel cell selection when the grid is scrolled

### DIFF
--- a/src/pbs_tui/rack_grid.py
+++ b/src/pbs_tui/rack_grid.py
@@ -596,10 +596,13 @@ class _RackPanel(ScrollableContainer):
     def on_click(self, event) -> None:
         if self._model is None:
             return
-        # event.x / event.y are container-local; add scroll offsets to map
-        # back to the underlying RenderModel's absolute coordinates.
-        col = int(event.x) + int(self.scroll_offset.x)
-        row = int(event.y) + int(self.scroll_offset.y)
+        # event.x / event.y are already in the inner Static's content space:
+        # Textual applies this scroll container's offset to the child's region
+        # before delivering the click, so they map directly to RenderModel
+        # (row, col). Adding scroll_offset here would double-count and select
+        # the wrong cell once the panel is scrolled.
+        col = int(event.x)
+        row = int(event.y)
         node_name = self._model.cell_at(row, col)
         if node_name is not None:
             # Look up the owner directly from the pre-computed cell data.

--- a/tests/test_rack_grid.py
+++ b/tests/test_rack_grid.py
@@ -562,3 +562,109 @@ def test_job_list_filter_chip_click_clears_filter():
             assert cleared, "clicking the filter chip should clear the filter"
 
     asyncio.run(interact())
+
+
+# ---------------------------------------------------------------------------
+# Rack panel click mapping under scroll (left grid pane)
+# ---------------------------------------------------------------------------
+
+
+def _overflowing_layout(rack_rows: int, rack_cols: int) -> MachineLayout:
+    """A machine layout whose rendered grid overflows a small viewport on both
+    axes: *rack_rows* × *rack_cols* racks, each a 3×2 mini-grid."""
+    specs = {}
+    rows = []
+    slots = {}
+    for r in range(rack_rows):
+        row = []
+        for c in range(rack_cols):
+            name = f"R{r}_{c}"
+            specs[name] = RackSpec(name=name, rows=3, cols=2)
+            slots[name] = [f"{name}s{i}" for i in range(6)]
+            row.append(name)
+        rows.append(row)
+    return MachineLayout(name="t", rack_specs=specs, rack_rows=rows, rack_slots=slots)
+
+
+def test_rack_panel_click_selects_correct_cell_under_scroll():
+    """Clicking a node glyph must select that node in every scroll state.
+
+    Regression test: `_RackPanel.on_click` added `scroll_offset` to the click
+    coordinates, but Textual already delivers `event.x`/`event.y` in the inner
+    Static's content space (scroll applied). Adding the offset double-counted,
+    so clicks selected the wrong cell — or None — once the panel was scrolled.
+    """
+    import asyncio
+
+    from textual.app import App, ComposeResult
+    from textual.containers import Horizontal
+
+    from pbs_tui.rack_grid import _RackPanel, render_to_text
+
+    layout = _overflowing_layout(rack_rows=8, rack_cols=10)
+    snap = SchedulerSnapshot(
+        nodes=[
+            Node(name=n, state="job-exclusive")
+            for lst in layout.rack_slots.values()
+            for n in lst
+        ],
+        jobs=[],
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+    model = build_render_model(layout, snap, job_assignments={})
+    palette = _palette()
+    captured: list = []
+
+    class Probe(App):
+        def compose(self) -> ComposeResult:
+            with Horizontal():
+                yield _RackPanel(id="rp")
+
+        def on__rack_panel_cell_clicked(self, event) -> None:
+            captured.append(event.node_name)
+
+    async def interact() -> None:
+        app = Probe()
+        async with app.run_test(size=(50, 18)) as pilot:
+            panel = app.query_one("#rp", _RackPanel)
+            text = render_to_text(
+                model, palette=palette, running_jobs={}, selected_job_id=None
+            )
+            panel.update(text, model)
+            panel.focus()
+            await pilot.pause()
+            inner = panel.query_one("#rack_panel_inner")
+
+            def first_visible_target():
+                """A node whose glyph is on-screen and away from the left edge,
+                so a mis-mapped click lands on a *different* identifiable node."""
+                for name, cell in model.cells_by_node.items():
+                    sx = inner.region.offset.x + cell.col
+                    sy = inner.region.offset.y + cell.row
+                    if (
+                        panel.content_region.contains(sx, sy)
+                        and sx > panel.content_region.x + 1
+                    ):
+                        return name, sx, sy
+                return None
+
+            for label, (sox, soy) in [
+                ("unscrolled", (0, 0)),
+                ("v-scroll", (0, 8)),
+                ("h-scroll", (8, 0)),
+                ("both", (8, 8)),
+            ]:
+                panel.scroll_to(x=sox, y=soy, animate=False)
+                await pilot.pause()
+                target = first_visible_target()
+                assert target is not None, f"no visible target for {label}"
+                name, sx, sy = target
+                captured.clear()
+                await pilot.click("#rp", offset=(sx, sy))
+                await pilot.pause()
+                assert captured == [name], (
+                    f"{label} (scroll {sox},{soy}): clicked glyph of {name!r} "
+                    f"but panel reported {captured!r}"
+                )
+
+    asyncio.run(interact())


### PR DESCRIPTION
## Summary

Fixes the latent bug flagged during PR #20 review: clicking a node cell in the Racks-tab grid selects the **wrong** job (or nothing) once the grid is scrolled.

## Root cause

`_RackPanel.on_click` mapped clicks to model coordinates by **adding** the scroll offset:

```python
col = int(event.x) + int(self.scroll_offset.x)
row = int(event.y) + int(self.scroll_offset.y)
```

But the click lands on the inner `Static`, and in Textual `event.x`/`event.y` are already delivered in that child's **content space** — the screen applies the child's region origin (which includes the scroll offset) before forwarding the event (`screen.py`: `widget._forward_event(event._apply_offset(-region.x, -region.y))`). So adding `scroll_offset` again double-counts. The mapping was correct only at scroll offset 0, which is why manual testing never caught it.

Confirmed empirically against the real widget — clicking the on-screen glyph of a known node:

| condition | scroll | `event.(x,y)` | correct (`event` alone) | current (`+ scroll_offset`) |
|---|---|---|---|---|
| unscrolled | (0,0) | (1,2) | ✅ | ✅ |
| vertical | (0,8) | (1,10) | ✅ | ❌ wrong node |
| horizontal | (8,0) | (9,2) | ✅ | ❌ wrong node |
| both | (8,8) | (9,10) | ✅ | ❌ None |

## Fix

Use `event.x`/`event.y` directly (no manual offset). No padding correction is needed — Textual folds the container's `padding: 0 1` into the child's region origin before delivery.

## Testing

- New regression test clicks a node glyph under four scroll states (unscrolled / vertical / horizontal / both) and asserts the emitted `CellClicked` names the clicked node. It clicks the glyph position **over the inner Static** (not the padding gutter, which routes to the container and maps coordinates differently) and targets a cell away from the edges so a mis-map lands on a *different, identifiable* node.
- `170 passed`.
- Verified in the real app (sample data, Racks tab): clicking an occupied cell selects its owning job both scrolled and unscrolled.

## Notes

The sibling `_JobListWidget` (fixed in #20) sidesteps this whole class of bug by using one child widget per row, so Textual routes clicks directly with no coordinate math. `_RackPanel` renders a single text grid, so it still needs coordinate mapping — just without the erroneous offset.

## Summary by Sourcery

Fix rack grid cell click handling so selections map to the correct node when the rack panel is scrolled.

Bug Fixes:
- Ensure _RackPanel maps click coordinates correctly without double-counting scroll offset, so clicking a node glyph always selects the intended job under all scroll states.

Tests:
- Add regression test that clicks node cells under multiple scroll positions and asserts the rack panel reports the correct node for each click.